### PR TITLE
feat: make the parsed json response available in post-request scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,85 @@ Scripts can be embedded in the `.http` request directly or loaded from
 < path/to/script.js
 ```
 
-### Examples
+#### Scripting API
+
+##### setEnv(key string, value string)
+
+The runtime environment variables can be modified from either pre or post
+request script. No return value.
+
+```javascript
+setEnv('host', 'http://localhost:8000');
+```
+
+##### getEnv(key string)
+
+Returns the value of the environment variable `key`.
+
+```javascript
+getEnv('host'); // returns 'http://localhost:8000'
+```
+
+##### assert(condition boolean, message string)
+
+Some assertion which resolves to a boolean value can be made for the
+condition with a corresponding message. Each assertion is extracted
+from the scripting runtime and added to the Response object.
+
+```javascript
+assert(response.status === 200, 'response code is 200');
+```
+
+##### `request` and `response` objects
+
+The `response` object is available in the post-request script and the `request`
+object is available in both the pre and post-request scripts. Changes made to
+these objects are not reflected in the actual request or response, rather they
+are used for assertions, control flow, and setting up the environment. There
+are a few exceptions to this rule, such as the `skip` property on `request`,
+see the next section for more information.
+
+```javascript
+request = {
+    name: 'Create A User',
+    method: 'POST',
+    url: 'http://localhost:8000/users',
+    headers: {
+      'Content-Type': 'application/json',
+    }, 
+    body: `{
+        name: 'r2d2'
+    }`,
+}
+```
+
+```javascript
+response = {
+    status: 'OK',
+    statusCode: 200,
+    headers: {
+        'Content-Type': 'application/json',
+    },
+    body: `{
+        id: '1234',
+        name: 'r2d2'
+    }`,
+
+    // `json` is the parsed json body that is only available if the response Content-Type
+    // header contains `application/json`
+    json: {
+      id: '1234',
+      name: 'r2d2'
+    } 
+}
+```
+
+##### Skipping Requests (pre-request script)
+
+You can prevent the request from being made from pre-request scripts being
+setting the `skip` property on the `request` object to `true`
+
+#### Examples
 
 ```http request
 ### Create a User
@@ -63,7 +141,8 @@ Content-Type: application/json
 
 ### Running .http Files from Go Tests
 
-The package `treqs`, short for `Testing Requests`, provides functions for running `.http` files from Go tests.
+The package `treqs`, short for `Testing Requests`, provides functions
+for running `.http` files from Go tests.
 
 ```go
 package test


### PR DESCRIPTION
Expose a parsed JSON response in the post-request script runtime if the response Content-Type header contains `application/json`.