### PR TITLE
docs: Fix the name of assert function from README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Content-Type: application/json
 }
 
 < {% 
-    assertTrue(response.status === 200, 'response code is 200');
+    assert(response.status === 200, 'response code is 200');
 %}
 ```
 


### PR DESCRIPTION
The assert function should be assert instead of `assertTrue`.